### PR TITLE
fix(cves): fixes around cve-2022-49043

### DIFF
--- a/image-descriptors/telicent-base-java.yaml
+++ b/image-descriptors/telicent-base-java.yaml
@@ -46,6 +46,7 @@ modules:
    - path: ../modules
   install:
     - name: telicent.container.util.pkg-update
+    - name: telicent.container.patches.cve.2022-49043
     - name: telicent.container.util.tzdata
     - name: telicent.container.tar-gzip
     - name: telicent.container.openjdk

--- a/image-descriptors/telicent-base-nginx127.yaml
+++ b/image-descriptors/telicent-base-nginx127.yaml
@@ -49,6 +49,7 @@ modules:
   repositories:
    - path: ../modules
   install:
+    - name: telicent.container.patches.cve.2022-49043
     - name: telicent.container.nginx
     - name: telicent.container.util.cleanup.gcc
     - name: telicent.container.util.cleanup

--- a/image-descriptors/telicent-base-nodejs20.yaml
+++ b/image-descriptors/telicent-base-nodejs20.yaml
@@ -52,6 +52,7 @@ modules:
   repositories:
    - path: ../modules
   install:
+    - name: telicent.container.patches.cve.2022-49043
     - name: telicent.container.nodejs
     #- name: telicent.container.util.cleanup.npm
     - name: telicent.container.util.cleanup

--- a/image-descriptors/telicent-base-python311.yaml
+++ b/image-descriptors/telicent-base-python311.yaml
@@ -59,6 +59,7 @@ modules:
     - path: ../modules
   install:
       - name: telicent.container.util.pkg-update
+      - name: telicent.container.patches.cve.2022-49043
       - name: telicent.container.util.tzdata
       - name: telicent.container.user
       - name: telicent.container.python311-microdnf

--- a/image-descriptors/telicent-base-python312.yaml
+++ b/image-descriptors/telicent-base-python312.yaml
@@ -58,6 +58,7 @@ modules:
   repositories:
    - path: ../modules
   install:
+    - name: telicent.container.patches.cve.2022-49043
     - name: telicent.container.util.pkg-update
     - name: telicent.container.util.tzdata
     - name: telicent.container.user

--- a/modules/patches/cve/CVE-2022-49043/module.yaml
+++ b/modules/patches/cve/CVE-2022-49043/module.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+
+name: "telicent.container.patches.cve.2022-49043"
+version: "1.0.0"
+
+description: "Applies fixes for CVE-2022-49043"
+
+packages:
+  install:
+    - openssl


### PR DESCRIPTION
This patch needs removed on next release of ubi9 - new version of the lib will be included by default.