### PR TITLE
fix: correct nodever in nodejs module

### DIFF
--- a/modules/nodejs/20/module.yaml
+++ b/modules/nodejs/20/module.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "telicent.container.nodejs"
 description: "Installs specified NodeJS version."
-version: &nodever "3.13.0"
+version: &nodever "20"
 
 labels:
 - name: "org.telicent.product"


### PR DESCRIPTION
Currently we do two things in modules/nodejs/20/module.yaml:
- First we set the microdnf module stream for nodejs is set (to 20) here: modules/util/pkg-nodejs/module.yaml 
- Then we just install the latest nodejs package (from that stream). 

nodever is currently only used in metadata.