### PR TITLE
fix: reduce software footprint after compilation

### DIFF
--- a/modules/util/cleanup/gcc/module.yaml
+++ b/modules/util/cleanup/gcc/module.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "telicent.container.util.cleanup.gcc"
 version: "1.0.0"
 
-description: "Cleans up gcc and other compliation tools to reduce image size following complication of binary from source."
+description: "Cleans up gcc and other compilation tools/libraries to reduce image size following complication of binary from source."
 
 packages:
   remove:


### PR DESCRIPTION
to avoid unnecessary mitigation of CVEs relating to dev packages on really required for compliation and not runtime