### PR TITLE
fix: disabling (for time being) images that are not in active development or use, thus unlikely to be fixed.

### DIFF
--- a/.github/workflows/periodic-cve-scan-published-java-images.yaml
+++ b/.github/workflows/periodic-cve-scan-published-java-images.yaml
@@ -16,9 +16,9 @@ jobs:
           - { image: "telicent/smart-cache-elastic-can-index:latest", artifact: "smart-cache-elastic-can-index" }
           - { image: "telicent/rdf-abac-evaluator:latest", artifact: "rdf-abac-evaluator" }
           - { image: "telicent/smart-cache-entity-resolution-api:latest", artifact: "smart-cache-entity-resolution-api" }
-          - { image: "telicent/telicent-pbac-federation-filter:latest", artifact: "telicent-pbac-federation-filter" }
-          - { image: "telicent/telicent-federation-client:latest", artifact: "telicent-federation-client" }
-          - { image: "telicent/telicent-federation-server:latest", artifact: "telicent-federation-server" }
+#          - { image: "telicent/telicent-pbac-federation-filter:latest", artifact: "telicent-pbac-federation-filter" }
+#          - { image: "telicent/telicent-federation-client:latest", artifact: "telicent-federation-client" }
+#          - { image: "telicent/telicent-federation-server:latest", artifact: "telicent-federation-server" }
       fail-fast: false
     with:
       IMAGE_REF: ${{ matrix.image-artifact.image }}
@@ -35,9 +35,9 @@ jobs:
           - { image: "telicent/smart-cache-entity-resolution-api:latest", artifact: "smart-cache-entity-resolution-api" }
           - { image: "telicent/smart-cache-elastic-can-index:latest", artifact: "smart-cache-elastic-can-index" }
           - { image: "telicent/rdf-abac-evaluator:latest", artifact: "rdf-abac-evaluator" }
-          - { image: "telicent/telicent-pbac-federation-filter:latest", artifact: "telicent-pbac-federation-filter" }
-          - { image: "telicent/telicent-federation-client:latest", artifact: "telicent-federation-client" }
-          - { image: "telicent/telicent-federation-server:latest", artifact: "telicent-federation-server" }
+#          - { image: "telicent/telicent-pbac-federation-filter:latest", artifact: "telicent-pbac-federation-filter" }
+#          - { image: "telicent/telicent-federation-client:latest", artifact: "telicent-federation-client" }
+#          - { image: "telicent/telicent-federation-server:latest", artifact: "telicent-federation-server" }
       fail-fast: false
     with:
       IMAGE_REF: ${{ matrix.image-artifact.image }}


### PR DESCRIPTION
I'll not merge it until after this has been merged and a new release put out there just to show that it works!
https://github.com/telicent-oss/rdf-abac-evaluator/pull/47