### PR TITLE
Remove krb5-libs to resolve CVE-2022-37967 (CORE-744)

### DIFF
--- a/image-descriptors/telicent-base-java.yaml
+++ b/image-descriptors/telicent-base-java.yaml
@@ -53,5 +53,6 @@ modules:
     - name: telicent.container.dumb-init
       version: "1.2.5"
     - name: telicent.container.utils.cleanup.tar-gzip
+    - name: telicent.container.util.cleanup.krb5-libs
     - name: telicent.container.util.devtools
 

--- a/modules/util/cleanup/krb5-libs/module.yaml
+++ b/modules/util/cleanup/krb5-libs/module.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+
+name: "telicent.container.util.cleanup.krb5-libs"
+version: "1.0.0"
+
+# We don't use Kerberos authentication for anything, nor is this package required
+# by anything else.  Plus the version in the RedHat UBI base has CVE-2022-37967 
+# which is rated High so explicitly remove it
+description: "Removes krb5-libs from OS"
+
+packages:
+  remove:
+    - krb5-libs


### PR DESCRIPTION
We don't use Kerberos authentication so as it has a High severity CVE against the package remove it entirely