### PR TITLE
Ignore CVE-2022-37967 (CORE-774)

### DIFF
--- a/.github/workflows/reusable-image-builder.yaml
+++ b/.github/workflows/reusable-image-builder.yaml
@@ -41,7 +41,6 @@ jobs:
             ref: ${{ inputs.TAG }}
             fetch-depth: 0
 
-
         - name: Install Python and PIP
           run: |
             sudo apt-get update
@@ -55,7 +54,6 @@ jobs:
         - name: Generate Dockerfile
           run: |
             cekit --descriptor image-descriptors/${{ matrix.image }}.yaml build --dry-run docker 
-
 
         - name: Extract Image Version and Name
           id: extract
@@ -126,60 +124,13 @@ jobs:
             fail-build: true
             only-fixed: ${{ inputs.SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE }}
 
-        - name: Trivy Cache
-          id: trivy-cache
-          uses: yogeshlonkar/trivy-cache-action@v0.1.8
+        - name: Trivy Image Scan
+          id: trivy-scan
+          uses: telicent-oss/trivy-action@v1
           with:
-            gh-token: ${{ secrets.GITHUB_TOKEN }}
-            prefix: ${{ github.repository_id }}
-
-        - name: Download Trivy Java DB
-          if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
-          uses: aquasecurity/trivy-action@master
-          env:
-            TRIVY_DOWNLOAD_JAVA_DB_ONLY: true
-            TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:1
-          with:
+            scan-name: ${{ steps.extract.outputs.image_name }}
+            scan-ref: telicent/${{ steps.extract.outputs.image_name }}:${{ steps.extract.outputs.image_version }}
             scan-type: image
-            timeout: 10m0s
-            cache-dir: .trivy
-            # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-            cache: false
-
-        - name: Download Trivy Vulnerability DB
-          if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
-          uses: aquasecurity/trivy-action@master
-          env:
-            TRIVY_DOWNLOAD_DB_ONLY: true
-            TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db:2
-          with:
-            scan-type: image
-            timeout: 10m0s
-            cache-dir: .trivy
-            # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-            cache: false
-
-        - name: Trivy Vulnerability Scan
-          uses: aquasecurity/trivy-action@master
-          env:
-            TRIVY_SKIP_DB_UPDATE: true
-            TRIVY_SKIP_JAVA_DB_UPDATE: true
-          with:
-            scan-type: "image"
-            image-ref: telicent/${{ steps.extract.outputs.image_name }}:${{ steps.extract.outputs.image_version }}
-            output: trivy-docker-report.json
-            format: json
-            exit-code: 0
-            cache-dir: .trivy
-            # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-            cache: false
-
-        - name: Upload Vulnerability Scan Results
-          uses: actions/upload-artifact@v4.4.3
-          with:
-            name: trivy-docker-report-${{ steps.extract.outputs.image_name }}-${{ steps.extract.outputs.image_version }}
-            path: trivy-docker-report.json
-            retention-days: 30
 
         - name: Generate SBOM for image
           uses: aquasecurity/trivy-action@master
@@ -204,23 +155,7 @@ jobs:
           uses: softprops/action-gh-release@v2.0.8
           with:
             files: |
-              trivy-docker-report.json
-
-        - name: Fail Build on High/Critical Vulnerabilities
-          uses: aquasecurity/trivy-action@master
-          env:
-            TRIVY_SKIP_DB_UPDATE: true
-            TRIVY_SKIP_JAVA_DB_UPDATE: true
-          with:
-            scan-type: "image"
-            image-ref:  telicent/${{ steps.extract.outputs.image_name }}:${{ steps.extract.outputs.image_version }}
-            format: table
-            severity: HIGH,CRITICAL
-            ignore-unfixed: true
-            exit-code: 1
-            cache-dir: .trivy
-            # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-            cache: false
+              ${{ steps.trivy-scan.outputs.scan-results-file }}
 
   notify-teams:
     name: Notify Teams on Workflow Result

--- a/.vex/CVE-2022-37967.openvex.json
+++ b/.vex/CVE-2022-37967.openvex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-8d152af92812e871725cdd72b76ac9a5e1fd04271f77e239c4709f3b00ca1bef",
+  "author": "Telicent Ltd",
+  "timestamp": "2025-04-03T10:03:24.07451+01:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2022-37967"
+      },
+      "timestamp": "2025-04-03T10:03:24.07451+01:00",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/krb5-libs@1.21.1-4.el9_5?arch=x86_64\u0026distro=redhat-9.5"
+        },
+        {
+          "@id": "pkg:rpm/redhat/krb5-libs@1.21.1-4.el9_5?arch=aarch64\u0026distro=redhat-9.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Telicent applications do not use Kerberos authentication. Additionally exploiting this vulnerability also requires a vulnerable samba package, which is not present in our images, or connecting to a vulnerable Active Directory service.  As this vulnerability with samba/Active Directory has been known for some time, were an adversary able to force Kerberos authentication to happen somehow, they would also need a vulnerable Active Directory server present in the environment."
+    }
+  ]
+}


### PR DESCRIPTION
Per our analysis we are not affected by this CVE so add a VEX statement to that affect.

# Related Issues and PRs

- This is intended for use in conjunction with forthcoming VEX support in telicent-oss/trivy-action#4