### PR TITLE
Set USES_JAVA flag on Periodic CVE scans

### DIFF
--- a/.github/workflows/periodic-cve-scan-published-images.yaml
+++ b/.github/workflows/periodic-cve-scan-published-images.yaml
@@ -38,6 +38,7 @@ jobs:
     with:
       IMAGE_REF: ${{ matrix.image-artifact.image }}
       SCAN_NAME: ${{ matrix.image-artifact.artifact }}
+      USES_JAVA: true
     secrets: inherit
 
   notify-teams:

--- a/.github/workflows/periodic-cve-scan-published-java-images.yaml
+++ b/.github/workflows/periodic-cve-scan-published-java-images.yaml
@@ -42,6 +42,7 @@ jobs:
     with:
       IMAGE_REF: ${{ matrix.image-artifact.image }}
       SCAN_NAME: ${{ matrix.image-artifact.artifact }}
+      USES_JAVA: true
     secrets: inherit
 
   notify-teams:


### PR DESCRIPTION
With the recent improvements to the shared Trivy workflows for Telicent we now need to set the `USES_JAVA` flag to `true` as otherwise the Trivy Java DB won't be cached and image scans will fail due to the lack of it