### PR TITLE
chore: Fix notification images

### DIFF
--- a/.github/workflows/periodic-cve-scan-published-images.yaml
+++ b/.github/workflows/periodic-cve-scan-published-images.yaml
@@ -52,7 +52,7 @@ jobs:
           TEAMS_WORKFLOW_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
         run: |
           build_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          error_image_url="https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/error-transparent.png"
+          error_image_url="https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/error-transparent.png?raw=true"
           cat > payload.json << EOF
           {
             "attachments": [
@@ -65,7 +65,7 @@ jobs:
                   "body": [
                     {
                       "type": "Image",
-                      "url": "https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/error-transparent.png",
+                      "url": "$error_image_url",
                       "altText": "Error Image",
                       "size": "medium",
                     },

--- a/.github/workflows/periodic-cve-scan-published-java-images.yaml
+++ b/.github/workflows/periodic-cve-scan-published-java-images.yaml
@@ -56,7 +56,7 @@ jobs:
           TEAMS_WORKFLOW_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
         run: |
           build_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          error_image_url="https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/error-transparent.png"
+          error_image_url="https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/error-transparent.png?raw=true"
           cat > payload.json << EOF
           {
             "attachments": [
@@ -69,7 +69,7 @@ jobs:
                   "body": [
                     {
                       "type": "Image",
-                      "url": "https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/error-transparent.png",
+                      "url": "$error_image_url",
                       "altText": "Error Image",
                       "size": "medium",
                     },

--- a/.github/workflows/reusable-image-builder.yaml
+++ b/.github/workflows/reusable-image-builder.yaml
@@ -172,11 +172,11 @@ jobs:
         run: |
           build_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ "$JOB_STATUS" = "success" ]; then
-            icon_url="https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/check-green.png"
+            icon_url="https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/check-green.png?raw=true"
             message_title="Workflow Success: ${{ github.workflow }}"
             message_text="The build and push process for the image completed successfully. Details are below:"
           else
-            icon_url="https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/error-transparent.png"
+            icon_url="https://github.com/telicent-oss/telicent-base-images/blob/main/.github/workflows/assets/error-transparent.png?raw=true"
             message_title="Workflow Failure: ${{ github.workflow }}"
             message_text="The build and push process for the image has failed. See details below:"
           fi


### PR DESCRIPTION
Need to add `?raw=true` onto the URLs otherwise GitHub serves a HTML page and not the image itself which leads to the image not rendering in the Teams notifications