### PR TITLE
Update reusable-image-builder.yaml

### DIFF
--- a/.github/workflows/reusable-image-builder.yaml
+++ b/.github/workflows/reusable-image-builder.yaml
@@ -131,6 +131,7 @@ jobs:
             scan-name: ${{ steps.extract.outputs.image_name }}
             scan-ref: telicent/${{ steps.extract.outputs.image_name }}:${{ steps.extract.outputs.image_version }}
             scan-type: image
+            uses-java: true
 
         - name: Generate SBOM for image
           uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
Again set `uses-java` flag on `telicent-oss/trivy-action` usage to avoid builds failing incorrectly

@TelicentPaul This is why your attempted release just now failed