### PR TITLE
fix: Keep tar/gzip in Java base images (CORE-802)

### DIFF
--- a/image-descriptors/telicent-base-java.yaml
+++ b/image-descriptors/telicent-base-java.yaml
@@ -52,6 +52,5 @@ modules:
       version: "21"
     - name: telicent.container.dumb-init
       version: "1.2.5"
-    - name: telicent.container.utils.cleanup.tar-gzip
     - name: telicent.container.util.devtools
 


### PR DESCRIPTION
In-line with Python images.  It'll allow us to run kubectl cp commands for investigation/debugging purposes. 