### PR TITLE
fix(cicd): Don't propagate TRIVY_VEX env

### DIFF
--- a/.github/workflows/reusable-image-builder.yaml
+++ b/.github/workflows/reusable-image-builder.yaml
@@ -135,6 +135,11 @@ jobs:
 
         - name: Generate SBOM for image
           uses: aquasecurity/trivy-action@master
+          env:
+            # NB - Our prior Trivy step MAY generate a TRIVY_VEX file and add it to GITHUB_ENV but it also removes that
+            #      file thus subsequent Trivy steps, like this one, can fail due to the missing file.  We can however
+            #      explicitly override it to an empty string to avoid that.
+            TRIVY_VEX: ""
           with:
             scan-type: 'image'
             format: 'cyclonedx'


### PR DESCRIPTION
Fixes a bug in reusable-image-builder.yaml workflow where our `telicent-oss/trivy-action` would set `TRIVY_VEX` in the `GITHUB_ENV` to a file, but then clean up that file.  Subsequent calls to aquasecurity/trivy-action would pick up the `TRIVY_VEX` env var and fail because the specified file does not exist.  By explicitly resetting that variable to empty we avoid this bug.