### PR TITLE
fix: adding vex statement for CVE-2025-4638

### DIFF
--- a/.vex/CVE-2025-4638.openvex.json
+++ b/.vex/CVE-2025-4638.openvex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-020f70f1f631b1f72657f5eff3c98ebcc23ae39fdcb61abdd9685852309efa7e",
+  "author": "Telicent Ltd",
+  "timestamp": "2025-05-19T10:45:18.549078+01:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-4638"
+      },
+      "timestamp": "2025-05-19T10:45:18.549079+01:00",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64&distro=redhat-9.5"
+        },
+        {
+          "@id": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=redhat-9.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Based on our analysis, the specific configuration and usage of zlib in our products does not utilize the vulnerable code path.  Further investigation has shown that while the package is present, the vulnerable code is not reachable in our application(s)."
+    }
+  ]
+}


### PR DESCRIPTION
We believe the current reporting of this CVE to be an erroneous false positive as we do not use pcl (only zlib) and the version of zlib we use, v1.2.11 has the fix.

Better to remove this from our reporting.