### PR TITLE
fix(2025-06-04T14:20:20.357Z): rebuild for new node

### DIFF
--- a/image-descriptors/telicent-base-nodejs20.yaml
+++ b/image-descriptors/telicent-base-nodejs20.yaml
@@ -56,3 +56,7 @@ modules:
     - name: telicent.container.util.cleanup.microdnf
     - name: telicent.container.util.devtools
 
+# CHANGE_CHECKSUM_TO_FORCE_REBUILD
+# Base: v1.2.14
+# When: 2025-06-04T14:20:20.357Z
+# Reason: Get security patch in nodejs 20.19.2


### PR DESCRIPTION
https://telicent.atlassian.net/browse/TELFE-1174

**IMPORTANT - Grype Db is lagging yesterdays fix**: For CVE-2025-23166, Grype Db's  [FIXED IN field is empty](https://github.com/telicent-oss/telicent-base-images/actions/runs/15445211619/job/43472871005#step:14:51), BUT NodeJS and Redhat say 20.19.2 resolves the issue:
- https://nodejs.org/en/blog/vulnerability/may-2025-security-releases
- https://access.redhat.com/errata/RHSA-2025:8468

# Work done

Trigger rebuild with node 20.19.2 (released yesterday)

I believe [build_resolver.sh](https://github.com/telicent-oss/telicent-base-images/blob/main/build_resolver.sh#L124) uses "dumb" git diffs to work out what has changed. 

So I **_think_** simply adding a comment to the node image will trigger a release

# Outcome

* Image: [telicent/telicent-nodejs20/1.2.15](https://hub.docker.com/layers/telicent/telicent-nodejs20/1.2.15/images/sha256-475d0b73b94baf40aedfd55f1734e9055ad869caae80fb5743aa886504a6e907)
* Build logs show [tag  v1.2.5](https://github.com/telicent-oss/telicent-base-images/actions/runs/15445211619/job/43472871005#step:11:42), the version of [Node is 20.19.2](https://github.com/telicent-oss/telicent-base-images/actions/runs/15445211619/job/43472871005#step:11:625)

<details>
	<summary>Pic of build logs</summary>

	As build logs perish, here is a pic for posterity:

![Screenshot 2025-06-04 at 15 43 54](https://github.com/user-attachments/assets/aae4ceec-a076-4b27-8337-1a04edc1a43e)

</details>