### PR TITLE
fix: adding vex statement for CVE-2025-5702 (telicent-nginx1.27 specific add).

### DIFF
--- a/.github/workflows/reusable-image-builder.yaml
+++ b/.github/workflows/reusable-image-builder.yaml
@@ -100,29 +100,13 @@ jobs:
               "telicent/${{ steps.extract.outputs.image_name }}:latest"
               "telicent/${{ steps.extract.outputs.image_name }}:${{ steps.extract.outputs.image_version }}"
 
-        - name: Grype Container Vulnerability Scan
+        - name: Grype Image Scan
           id: grype-scan
-          uses: anchore/scan-action@v6.2.0
+          uses: telicent-oss/grype-action@v1
           with:
-            image: telicent/${{ steps.extract.outputs.image_name }}:${{ steps.extract.outputs.image_version }}
-            output-format: json
-            fail-build: false
-
-        - name: Upload Vulnerability Scan Results
-          uses: actions/upload-artifact@v4.4.3
-          with:
-            name: grype-docker-report-${{ steps.extract.outputs.image_name }}-${{ steps.extract.outputs.image_version }}
-            path: ${{ steps.grype-scan.outputs.json }}
-            retention-days: 30
-
-        - name: Fail Build on High/Critical Vulnerabilities
-          uses: anchore/scan-action@v6.2.0
-          with:
-            image: telicent/${{ steps.extract.outputs.image_name }}:${{ steps.extract.outputs.image_version }}
-            output-format: table
-            severity-cutoff: high
-            fail-build: true
-            only-fixed: ${{ inputs.SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE }}
+            scan-name: ${{ steps.extract.outputs.image_name }}
+            scan-ref: telicent/${{ steps.extract.outputs.image_name }}:${{ steps.extract.outputs.image_version }}
+            scan-type: image
 
         - name: Trivy Image Scan
           id: trivy-scan

--- a/.vex/CVE-2025-5702.openvex.json
+++ b/.vex/CVE-2025-5702.openvex.json
@@ -34,6 +34,12 @@
         },
         {
           "@id": "pkg:rpm/redhat/glibc-langpack-en@2.34-168.el9_6.14?arch=x86_64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-headers@2.34-168.el9_6.14?arch=aarch64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-headers@2.34-168.el9_6.14?arch=x86_64\u0026distro=redhat-9.6"
         }
       ],
       "status": "not_affected",


### PR DESCRIPTION
 Migrating to Telicent Grype scan too.
 
 
 **Note:** this uses a bunch of the trivy/grype processes in the Shared Workflows that aren't fully migrated to the internal telicent trivy/grype actions and so will still fail. 