### PR TITLE
fix: adding vex statement for CVE-2025-5702 (telicent-nodejs20 specific add)

### DIFF
--- a/.vex/CVE-2025-5702.openvex.json
+++ b/.vex/CVE-2025-5702.openvex.json
@@ -40,6 +40,36 @@
         },
         {
           "@id": "pkg:rpm/redhat/glibc-headers@2.34-168.el9_6.14?arch=x86_64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc@2.34-168.el9_6.19?arch=aarch64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc@2.34-168.el9_6.19?arch=x86_64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.19?arch=aarch64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-common@2.34-168.el9_6.19?arch=x86_64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.19?arch=aarch64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-168.el9_6.19?arch=x86_64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-langpack-en@2.34-168.el9_6.19?arch=aarch64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-langpack-en@2.34-168.el9_6.19?arch=x86_64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-headers@2.34-168.el9_6.19?arch=aarch64\u0026distro=redhat-9.6"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glibc-headers@2.34-168.el9_6.19?arch=x86_64\u0026distro=redhat-9.6"
         }
       ],
       "status": "not_affected",


### PR DESCRIPTION
Since it's using a slightly different flavour of Red Hat. 