### PR TITLE
fix: updating Red Hat UBI-9 image

### DIFF
--- a/image-descriptors/telicent-base-java.yaml
+++ b/image-descriptors/telicent-base-java.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-from: "redhat/ubi9-minimal:9.6-1752069876"
+from: "redhat/ubi9-minimal:9.6-1752587672"
 
 name: &name "telicent-java21"
-version: &version "1.2.16"
+version: &version "1.2.17"
 description: "Telicent's java base image built on Red Hat UBI9 minimal."
 
 # Ensure compliance with Red Hat UBI EULA

--- a/image-descriptors/telicent-base-nginx124.yaml
+++ b/image-descriptors/telicent-base-nginx124.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-from: "redhat/ubi9-minimal:9.6-1752069876"
+from: "redhat/ubi9-minimal:9.6-1752587672"
 
 name: &name "telicent-nginx1.24"
-version: &version "1.0.16"
+version: &version "1.0.17"
 description: "Telicent's NGINX base image built on Red Hat UBI9 minimal."
 
 # Ensure compliance with Red Hat UBI EULA

--- a/image-descriptors/telicent-base-nginx127.yaml
+++ b/image-descriptors/telicent-base-nginx127.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-from: "redhat/ubi9-minimal:9.6-1752069876"
+from: "redhat/ubi9-minimal:9.6-1752587672"
 
 name: &name "telicent-nginx1.27"
-version: &version "1.2.19"
+version: &version "1.2.20"
 description: "Telicent's NGINX base image built on Red Hat UBI9 minimal."
 
 # Ensure compliance with Red Hat UBI EULA

--- a/image-descriptors/telicent-base-nodejs20.yaml
+++ b/image-descriptors/telicent-base-nodejs20.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-from: "redhat/ubi9-minimal:9.6-1752069876"
+from: "redhat/ubi9-minimal:9.6-1752587672"
 
 name: &name "telicent-nodejs20"
-version: &version "1.2.21"
+version: &version "1.2.22"
 description: "Telicent's NodeJS base image built on Red Hat UBI9 minimal."
 
 # Ensure compliance with Red Hat UBI EULA

--- a/image-descriptors/telicent-base-python312.yaml
+++ b/image-descriptors/telicent-base-python312.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-from: "redhat/ubi9-minimal:9.6-1752069876"
+from: "redhat/ubi9-minimal:9.6-1752587672"
 
 name: &name "telicent-python3.12"
-version: &version "1.2.17"
+version: &version "1.2.18"
 description: "Telicent's base python 3.12 image built on Red Hat UBI9 minimal"
 
 labels:


### PR DESCRIPTION
To resolve CVE-2025-30749, CVE-2025-50106, and CVE-2025-50059.
Update from  From 9.6-1752069876 to 9.6-1752587672.

