### PR TITLE
chore: Bump Java image version (CORE-889)

### DIFF
--- a/image-descriptors/telicent-base-java.yaml
+++ b/image-descriptors/telicent-base-java.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 from: "redhat/ubi9-minimal:9.6-1752587672"
 
 name: &name "telicent-java21"
-version: &version "1.2.18"
+version: &version "1.2.19"
 description: "Telicent's java base image built on Red Hat UBI9 minimal."
 
 # Ensure compliance with Red Hat UBI EULA


### PR DESCRIPTION
Bumps the Java image version to force a rebuild to make it pick up the now released JDK 21.0.8 builds and resolve outstanding CVEs on the Java image