### PR TITLE
fix: Adding CVE-2025-50106

### DIFF
--- a/.vex/CVE-2025-50106.openvex.json
+++ b/.vex/CVE-2025-50106.openvex.json
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1b9172b9-4f84-465d-b157-1fcd35abf78d",
+  "author": "Telicent Ltd",
+  "timestamp": "2025-07-22T13:19:13Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-50106"
+      },
+      "timestamp": "2025-07-22T13:19:13Z",
+      "products": [
+        {
+          "@id": "pkg:generic/oracle/openjdk@21.0.7%2B6-LTS?repository_url=https%3A%2F%2Fgithub.com%2Fadoptium%2Fjdk21u.git"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "This vulnerability applies to deployments using Java Web Start and Java applets. It does not apply to server deployments that load and run only trusted code, such as is the case with Telicent applications."
+    }
+  ]
+}


### PR DESCRIPTION
For the same reasons as previously added CVE-2025-50059.

Grype flags this but Trivy doesn't care, which is an added wrinkle.