### PR TITLE
fix: Fix build_resolver.sh script

### DIFF
--- a/build_resolver.sh
+++ b/build_resolver.sh
@@ -14,7 +14,7 @@ DEBUG=${DEBUG:-0}
 
 function debug_print() {
   if [[ "$DEBUG" == 1 ]]; then
-    echo "[DEBUG] $1"
+    echo "[DEBUG] $1" >&2
   fi
 }
 
@@ -34,9 +34,6 @@ function get_commit_range() {
   fi
 }
 
-declare -a module_map_keys
-declare -a module_map_values
-
 function build_module_map() {
   find modules -name module.yaml -print0 | while IFS= read -r -d $'\0' module_yaml; do
     module_name=$(grep -m 1 'name:' "$module_yaml" | sed -E 's/^name: *"?([^"]*)"?/\1/' | tr -d ' ' | tr -d '\n')
@@ -50,9 +47,8 @@ function build_module_map() {
 
     module_dir=$(dirname "$module_yaml")
 
-    # Simulate associative array
-    module_map_keys+=("$module_name")
-    module_map_values+=("$module_dir")
+    # Write a temporary pointer file to the module
+    echo "$module_dir" > ".$module_name.pointer"
 
     debug_print "Mapped module $module_name to $module_dir"
   done
@@ -64,35 +60,23 @@ function extract_modules_from_install_section() {
   local in_install_section=false
   local modules_found=()
 
+  debug_print "Locating modules for descriptor $file"
+
+  cat "$file" | yq '.modules.install[].name' > .temp-modules
+
   while IFS= read -r line; do
-    if [[ "$line" =~ ^[[:space:]]*modules: ]]; then
-      in_modules_section=true
-      continue
-    fi
+    local module_name=$(echo "$line" | tr -d ' ' | tr -d '\n')
 
-    if [[ "$in_modules_section" && ! "$line" =~ ^[[:space:]] ]]; then
-      in_modules_section=false
-      in_install_section=false
+    if [[ -n "$module_name" ]]; then
+      debug_print "  Located module $module_name"
+      modules_found+=("$module_name")
     fi
+  done < .temp-modules
+  rm -f .temp-modules
 
-    if [[ "$in_modules_section" && "$line" =~ ^[[:space:]]*install: ]]; then
-      in_install_section=true
-      continue
-    fi
-
-    if [[ "$in_install_section" && ! "$line" =~ ^[[:space:]] ]]; then
-      in_install_section=false
-    fi
-
-    if $in_install_section && [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*name: ]]; then
-      local module_name=$(echo "$line" | grep -o '(?<=name: )\S+')
-      module_name=$(echo "$module_name" | tr -d ' ' | tr -d '\n')
-
-      if [[ -n "$module_name" ]]; then
-        modules_found+=("$module_name")
-      fi
-    fi
-  done < "$file"
+  if [ "${#modules_found[@]}" -eq 0 ]; then
+    debug_print "  No modules found"
+  fi
 
   echo "${modules_found[@]}"
 }
@@ -100,24 +84,14 @@ function extract_modules_from_install_section() {
 # Function to recursively check if a module or its dependencies have changed
 function track_module_dependencies() {
   local module_name=$1
-    # Simulate associative array lookup
-    local module_index=-1
-    for i in "${!module_map_keys[@]}"; do
-      if [[ "${module_map_keys[$i]}" == "$module_name" ]]; then
-        module_index="$i"
-        break
-      fi
-    done
-
-    if [[ "$module_index" -eq -1 ]]; then
-      echo "Module $module_name not found." >&2
-      return 1
-    fi
-
-    local module_path="${module_map_values[$module_index]}"
-
+  local pointer_file=".$module_name.pointer"
+  if [[ ! -f "$pointer_file" ]]; then
+    echo "Module $module_name not found (unknown module)." >&2
+  fi
+  local module_path=$(cat "$pointer_file")
+  
   if [[ -z "$module_path" ]]; then
-    echo "Module $module_name not found." >&2
+    echo "Module $module_name not found (no location)." >&2
     return 1
   fi
 
@@ -150,7 +124,7 @@ function check_modules_in_image_descriptor() {
   for module_name in "${modules_in_descriptor[@]}"; do
     debug_print "Checking module: $module_name in $descriptor_file"
     if track_module_dependencies "$module_name"; then
-      echo "$descriptor_file requires build since $module_name dependant on it has changed."
+      echo "$descriptor_file requires build since $module_name dependency has changed."
       return 0
     fi
   done
@@ -174,8 +148,10 @@ function detect_image_changes() {
 
   echo "----------------------------------------"
   echo "Module Map:"
-  for i in "${!module_map_keys[@]}"; do # Iterate through the keys
-    echo "Module: ${module_map_keys[$i]} => Path: ${module_map_values[$i]}"
+  for pointer_file in $(ls .*.pointer); do
+    module_name="${pointer_file%%.pointer}"
+    module_name="${module_name:1}"
+    echo "Module: ${module_name} => Path: $(cat "$pointer_file")"
   done
   echo "----------------------------------------"
 
@@ -197,11 +173,16 @@ function detect_image_changes() {
       image_name=$(basename "$descriptor" | awk -F'.' '{print $1}')
       affected_images+=("$image_name")
     else
+      debug_print "No direct changes to image descriptor: $descriptor"
+      debug_print "Checking for any changes to installed modules..."
       if check_modules_in_image_descriptor "$descriptor"; then
         echo "Image $descriptor modules have changed. Rebuild required."
         image_name=$(basename "$descriptor" | awk -F'.' '{print $1}')
         affected_images+=("$image_name")
       fi
+    fi
+    if [ "$DEBUG" -eq 1 ]; then
+      echo
     fi
   done < .changed-descriptors
   rm -f .changed-descriptors
@@ -228,3 +209,4 @@ if [[ "$1" == "use_last" ]]; then
 fi
 
 detect_image_changes "image-descriptors" $USE_LAST
+rm -f .*.pointer


### PR DESCRIPTION
The `build_resolver.sh` script was not correctly detecting changes to module files and thus not triggering image rebuilds when necessary. This commit refactors the script to make two main changes:

1. Use the `yq` tool to find the modules listed in image descriptor/module files rather than manual bash parsing of the file which was brittle
2. Rather than trying to build an associative array (which didn't work reliably) use temporary files to map module names to their on-disk locations

Also generally tidies up/improves some of the `DEBUG` logging in the script, and makes it go to stderr to avoid polluting the stdout return value from some methods

With this change @davec504's recent change that was not being correctly detected is now correctly detected in my local testing:

```
Base dir: image-descriptors
Start sha:v0.7.3 - End: HEAD
----------------------------------------
Module Map:
Module: .telicent.container.dumb-init => Path: modules/dumb-init
Module: .telicent.container.nginx-microdnf => Path: modules/nginx-microdnf/124
Module: .telicent.container.nginx => Path: modules/nginx/127
Module: .telicent.container.nginx129 => Path: modules/nginx/129
Module: .telicent.container.nodejs => Path: modules/nodejs/20
Module: .telicent.container.openjdk.base => Path: modules/jdk/jdk-base/base
Module: .telicent.container.openjdk => Path: modules/jdk/22
Module: .telicent.container.python-env => Path: modules/python/python-env
Module: .telicent.container.python.base => Path: modules/python/python-base
Module: .telicent.container.python => Path: modules/python/313
Module: .telicent.container.python312-microdnf => Path: modules/python/312-microdnf
Module: .telicent.container.tar-gzip => Path: modules/tar-gzip
Module: .telicent.container.user => Path: modules/user
Module: .telicent.container.util.cleanup.gcc => Path: modules/util/cleanup/gcc
Module: .telicent.container.util.cleanup.microdnf => Path: modules/util/cleanup/microdnf
Module: .telicent.container.util.cleanup.npm => Path: modules/util/cleanup/npm
Module: .telicent.container.util.cleanup.pkg-python => Path: modules/util/cleanup/python-pkg
Module: .telicent.container.util.debugtools => Path: modules/util/debugtools
Module: .telicent.container.util.devtools => Path: modules/util/devtools
Module: .telicent.container.util.perftools => Path: modules/util/perftools
Module: .telicent.container.util.pkg-nginx => Path: modules/util/pkg-nginx
Module: .telicent.container.util.pkg-nodejs => Path: modules/util/pkg-nodejs
Module: .telicent.container.util.pkg-update => Path: modules/util/pkg-update
Module: .telicent.container.util.pyenv-perms => Path: modules/util/pyenv-perms
Module: .telicent.container.util.python-packages => Path: modules/util/pkg-python
Module: .telicent.container.util.readlines => Path: modules/util/readlines
Module: .telicent.container.util.tzdata => Path: modules/util/tzdata
Module: .telicent.container.utils.cleanup.tar-gzip => Path: modules/util/cleanup/tar-gzip
----------------------------------------
Module telicent.container.nginx129 in modules/nginx/129 has changed.
image-descriptors/telicent-base-nginx129.yaml requires build since telicent.container.nginx129 dependency has changed.
Image image-descriptors/telicent-base-nginx129.yaml modules have changed. Rebuild required.
Affected images to rebuild:
telicent-base-nginx129
Changed image descriptor(s): telicent-base-nginx129
```

Note that if we compare this with the output from @davec504's recent PR merge we can see that the modules were not properly being detected:

```
Calling build resolver with use_last
Base dir: image-descriptors
Start sha:v0.7.3 - End: HEAD
----------------------------------------
Module Map:
----------------------------------------
No images need rebuilding.
```

Note that the Module Map is empty so no module changes can ever be correctly detected.