### PR TITLE
chore: Add VEX statement for CVE-2026-4878

### DIFF
--- a/.vex/CVE-2026-4878.openvex.json
+++ b/.vex/CVE-2026-4878.openvex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-c4408e3b-f55d-42be-b237-7bcd85838564",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-04-14T10:42:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-4878"
+      },
+      "timestamp": "2026-04-14T10:42:00Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/libcap@2.48-10.el9?arch=aarch64&distro=redhat-9.7"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcap@2.48-10.el9?arch=x86_64&distro=redhat-9.7"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "libcap is a low level OS library and Telicent application code does not use this, nor expose any code execution capabilities that might enable such use.  Additionally Telicent code is installed into containers with minimal permissions and this vulnerability relies upon the attacker controlling write access to a directory which they will not have in this scenario."
+    }
+  ]
+}


### PR DESCRIPTION
This is a vulnerability in a low level OS library which our code does not use.  Also the vulnerability relies on an attacker having write permissions into directories which our container images minimise/avoid entirely.