### PR TITLE
[Minor] Adding suppression for CVE-2026-33845 & CVE-2026-33846. 

### DIFF
--- a/.vex/CVE-2026-33845.openvex.json
+++ b/.vex/CVE-2026-33845.openvex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-11b23a4a-53e0-4585-ae3b-d84a7638f853",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-05-06T08:15:52Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33845"
+      },
+      "timestamp": "2026-05-06T08:15:52Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/gnutls@3.8.3-10.el9_7?arch=aarch64&distro=redhat-9.7"
+        },
+        {
+          "@id": "pkg:rpm/redhat/gnutls@3.8.3-10.el9_7?arch=x86_64&distro=redhat-9.7"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The base image contains GnuTLS, but does not itself initiate or terminate DTLS sessions and so isn;t affected"
+    }
+  ]
+}

--- a/.vex/CVE-2026-33846.openvex.json
+++ b/.vex/CVE-2026-33846.openvex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-3a65a00f-3e63-4b33-8e43-18bf14a9f4d8",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-05-06T08:15:52Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33846"
+      },
+      "timestamp": "2026-05-06T08:15:52Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/gnutls@3.8.3-10.el9_7?arch=aarch64&distro=redhat-9.7"
+        },
+        {
+          "@id": "pkg:rpm/redhat/gnutls@3.8.3-10.el9_7?arch=x86_64&distro=redhat-9.7"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The base image contains GnuTLS, but does not itself initiate or terminate DTLS sessions and so isn't affected."
+    }
+  ]
+}

--- a/trivy-with-vex.sh
+++ b/trivy-with-vex.sh
@@ -56,6 +56,7 @@
 
   trivy "$MODE" \
     --cache-dir "$CACHE_DIR" \
+    --skip-version-check \
     --show-suppressed \
     --severity HIGH,CRITICAL \
     "${TRIVY_ARGS[@]}" \


### PR DESCRIPTION
And also removing annoying warnings about upgrades from trivy.