### PR TITLE
Update CVE-2026-43689.openvex.json

### DIFF
--- a/.vex/CVE-2026-43689.openvex.json
+++ b/.vex/CVE-2026-43689.openvex.json
@@ -18,6 +18,20 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Our applications do not utilize the SSL/TLS transport layer of libthrift so the exposed certificate validation logic is never invoked."
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-7pwc-h2j2-rjgj"
+      },
+      "timestamp": "2026-04-29T11:44:55Z",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.thrift/libthrift@0.22.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Our applications do not utilize the SSL/TLS transport layer of libthrift so the exposed certificate validation logic is never invoked."
     }
   ]
 }


### PR DESCRIPTION
Grype has this vulnerability in its database under the GitHub ID not the CVE ID so suppression did not work for `grype` scans