### PR TITLE
Add suppression for CVE-2026-5598

### DIFF
--- a/.vex/CVE-2026-5598.openvex.json
+++ b/.vex/CVE-2026-5598.openvex.json
@@ -1,0 +1,37 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-e75e0b78-424c-45e3-a33a-7168a7472752",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-05-12T13:09:55Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-5598"
+      },
+      "timestamp": "2026-05-12T13:09:55Z",
+      "products": [
+        {
+          "@id": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.82"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Vulnerability relates to an experimental Post-Quantum Cryptography engine that is not used by any code or library in our applications."
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-p93r-85wp-75v3"
+      },
+      "timestamp": "2026-05-12T13:09:55Z",
+      "products": [
+        {
+          "@id": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.82"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Vulnerability relates to an experimental Post-Quantum Cryptography engine that is not used by any code or library in our applications."
+    }
+  ]
+}


### PR DESCRIPTION
This CVE relates to an experimental post-quantum cryptography engine that is not used by any code or library in our applications.