### PR TITLE
feat(node): add 22 long-term-support version

### DIFF
--- a/.dev/build-nodejs22.sh
+++ b/.dev/build-nodejs22.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESCRIPTOR="$REPO_ROOT/image-descriptors/telicent-base-nodejs22.yaml"
+
+echo "==> Building telicent-nodejs22 from $DESCRIPTOR"
+"$REPO_ROOT/.dev/build-image.sh" "$DESCRIPTOR"
+
+IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^telicent-nodejs22:" | head -1)
+if [[ -z "$IMAGE" ]]; then
+  echo "ERROR: no telicent-nodejs22 image found after build" >&2
+  exit 1
+fi
+
+echo "==> Verifying Node version in $IMAGE"
+NODE_VER=$(docker run --rm "$IMAGE" node --version)
+echo "    node $NODE_VER"
+
+MAJOR=$(echo "$NODE_VER" | sed 's/v\([0-9]*\).*/\1/')
+if [[ "$MAJOR" -lt 22 ]]; then
+  echo "ERROR: expected Node >=22, got $NODE_VER" >&2
+  exit 1
+fi
+
+echo "==> OK"

--- a/image-descriptors/telicent-base-nodejs22.yaml
+++ b/image-descriptors/telicent-base-nodejs22.yaml
@@ -2,9 +2,9 @@ schema_version: 1
 
 from: "redhat/ubi9-minimal:9.7-1777857961"
 
-name: &name "telicent-nodejs20"
-version: &version "1.2.48"
-description: "Telicent's NodeJS base image built on Red Hat UBI9 minimal."
+name: &name "telicent-nodejs22"
+version: &version "1.0.0"
+description: "Telicent's NodeJS 22 base image built on Red Hat UBI9 minimal."
 
 # Ensure compliance with Red Hat UBI EULA
 labels:
@@ -13,17 +13,17 @@ labels:
   - name: "version"
     value: *version
   - name: "description"
-    value: "Telicent's base NodeJS 20 image built on Red Hat UBI9 minimal."
+    value: "Telicent's base NodeJS 22 image built on Red Hat UBI9 minimal."
   - name: "com.redhat.license_terms"
     value: "https://www.redhat.com/en/about-red-hat-end-user-license-agreements#UBI" # DO NOT REMOVE
   - name: "io.k8s.display-name"
-    value: "Telicent UBI NodeJS 20 Base"
+    value: "Telicent UBI NodeJS 22 Base"
   - name: "io.openshift.tags"
-    value: "base ubi9 nodejs20"
+    value: "base ubi9 nodejs22"
   - name: "org.opencontainers.image.source"
     value: "https://github.com/telicent-oss/telicent-base-images"
   - name: "summary"
-    value: "Telicent Base NodeJS Image built from Red Hat Universal Base Image 9 with added non root default user"
+    value: "Telicent Base NodeJS 22 Image built from Red Hat Universal Base Image 9 with added non root default user"
   - name: "maintainer"
     value: "Telicent OSS <opensource@telicent.io>"
   - name: "vendor"
@@ -42,7 +42,7 @@ envs:
   - name: "LC_ALL"
     value: "en_US.UTF-8"
   - name: "NODEJS_VERSION"
-    value: "20"
+    value: "22"
 
 packages:
   manager: microdnf
@@ -53,10 +53,10 @@ modules:
    - path: ../modules
   install:
     - name: telicent.container.nodejs
-      version: "20"
+      version: "22"
     - name: telicent.container.util.cleanup.microdnf
     - name: telicent.container.util.devtools
 
 # CHANGE_CHECKSUM_TO_FORCE_REBUILD
-# Base: v1.2.14
-# When: 2025-06-04T14:20:20.357Z
+# Base: v1.0.0
+# When: 2026-05-15T00:00:00.000Z

--- a/modules/nodejs/22/exec.sh
+++ b/modules/nodejs/22/exec.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+microdnf -y module disable nodejs
+microdnf -y module enable nodejs:$NODEJS_VERSION

--- a/modules/nodejs/22/module.yaml
+++ b/modules/nodejs/22/module.yaml
@@ -1,0 +1,43 @@
+schema_version: 1
+
+name: "telicent.container.nodejs"
+description: "Installs specified NodeJS version."
+version: &nodever "22"
+
+labels:
+- name: "org.telicent.product"
+  value: "nodejs"
+- name: "org.telicent.product.version"
+  value: *nodever
+- name: "org.telicent.product.nodejs.version"
+  value: *nodever
+
+# NODEJS_VERSION is set at descriptor level (mirrors nodejs20 pattern).
+# telicent.container.util.pkg-nodejs is intentionally absent: that module
+# hard-codes NODEJS_VERSION=20 and would override the descriptor env.
+# exec.sh handles the microdnf module enable directly.
+# PATH/NPM_CONFIG_PREFIX/HOME are wired here (previously provided by pkg-nodejs).
+envs:
+  - name: "HOME"
+    value: "/home/user"
+  - name: NPM_CONFIG_PREFIX
+    value: "/home/user/.npm-global"
+  - name: PATH
+    value: "/home/user/node_modules/.bin/:/home/user/.npm-global/bin/:$PATH"
+
+modules:
+  install:
+    - name: telicent.container.user
+    - name: telicent.container.util.pkg-update
+    - name: telicent.container.util.tzdata
+    - name: telicent.container.tar-gzip
+
+packages:
+  install:
+    - glibc-langpack-en
+    - nodejs
+    - findutils
+    - which
+
+execute:
+  - script: exec.sh


### PR DESCRIPTION
Ticket: [TELDEVOPS-1092](https://telicent.atlassian.net/browse/TELDEVOPS-1092)

### Goal

Add Node.js 22 base image - current Active Long-Term-Support (EOL April 2028) (**v20 EOL this April**)

### Work Completed

- `telicent-base-nodejs22.yaml` 
	-  new image descriptor, UBI9 minimal, mirrors `nodejs20` pattern
- `modules/nodejs/22/`
- 	`module.yaml` + `exec.sh`
	- **handles `microdnf module enable nodejs:22` directly **
	(skips `pkg-nodejs` which hard-codes `NODEJS_VERSION=20`)
- `telicent-base-nodejs20.yaml` 
	-  pins `version: "20"` to match new pattern
- `.dev/build-nodejs22.sh` 
	-  local build + asserts `node --version` major ≥ 22

### Testing Method

`.dev/build-nodejs22.sh`. Builds image, checks node version

### Engineering Notes

- 🚨 `pkg-nodejs` excluded intentionally:  it hard-codes `NODEJS_VERSION=20` and would override the descriptor env. `exec.sh` owns the `microdnf module enable` directly.


[TELDEVOPS-1092]: https://telicent.atlassian.net/browse/TELDEVOPS-1092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ