### PR TITLE
feat(nginx): add nginx 1.30.1 module and image descriptor

### DIFF
--- a/.dev/build-nginx130.sh
+++ b/.dev/build-nginx130.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESCRIPTOR="$REPO_ROOT/image-descriptors/telicent-base-nginx130.yaml"
+
+echo "==> Building telicent-nginx1.30 from $DESCRIPTOR"
+"$REPO_ROOT/.dev/build-image.sh" "$DESCRIPTOR"
+
+IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^telicent-nginx1\.30:" | head -1)
+if [[ -z "$IMAGE" ]]; then
+  echo "ERROR: no telicent-nginx1.30 image found after build" >&2
+  exit 1
+fi
+
+echo "==> Verifying nginx version in $IMAGE"
+NGINX_VER=$(docker run --rm "$IMAGE" nginx -v 2>&1)
+echo "    $NGINX_VER"
+
+# nginx -v outputs: "nginx version: nginx/1.30.x"
+VERSION=$(echo "$NGINX_VER" | sed 's|.*nginx/\([0-9]*\.[0-9]*\).*|\1|')
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR=$(echo "$VERSION" | cut -d. -f2)
+
+if [[ "$MAJOR" -lt 1 ]] || { [[ "$MAJOR" -eq 1 ]] && [[ "$MINOR" -lt 30 ]]; }; then
+  echo "ERROR: expected nginx >=1.30, got $NGINX_VER" >&2
+  exit 1
+fi
+
+echo "==> OK"

--- a/image-descriptors/telicent-base-nginx130.yaml
+++ b/image-descriptors/telicent-base-nginx130.yaml
@@ -1,0 +1,56 @@
+schema_version: 1
+
+from: "redhat/ubi9-minimal:9.7-1777857961"
+
+name: &name "telicent-nginx1.30"
+version: &version "1.0.0"
+description: "Telicent's NGINX base image built on Red Hat UBI9 minimal."
+
+# Ensure compliance with Red Hat UBI EULA
+labels:
+  - name: "name"
+    value: *name
+  - name: "version"
+    value: *version
+  - name: "description"
+    value: "Telicent's base NGINX image built on Red Hat UBI9 minimal"
+  - name: "com.redhat.license_terms"
+    value: "https://www.redhat.com/en/about-red-hat-end-user-license-agreements#UBI" # DO NOT REMOVE
+  - name: "io.k8s.display-name"
+    value: "Telicent UBI NGINX Base"
+  - name: "io.openshift.tags"
+    value: "base ubi9 nginx130"
+  - name: "org.opencontainers.image.source"
+    value: "https://github.com/telicent-oss/telicent-base-images"
+  - name: "summary"
+    value: "Telicent Base NGINX built from Red Hat Universal Base Image 9 with added non root default user"
+  - name: "maintainer"
+    value: "Telicent OSS <opensource@telicent.io>"
+  - name: "vendor"
+    value: "Telicent OSS"
+  - name: "org.opencontainers.image.authors"
+    value: "Telicent OSS <opensource@telicent.io>"
+  - name: "org.opencontainers.image.vendor"
+    value: "Telicent OSS"
+
+ports:
+  - value: 8080
+
+envs:
+  - name: "LANG"
+    value: "en_US.UTF-8"
+  - name: "LC_ALL"
+    value: "en_US.UTF-8"
+packages:
+  manager: microdnf
+  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0 --enablerepo=ubi-9-appstream-rpms
+
+modules:
+  repositories:
+    - path: ../modules
+  install:
+    - name: telicent.container.util.pkg-update
+    - name: telicent.container.nginx130
+    - name: telicent.container.util.cleanup.gcc
+    - name: telicent.container.util.cleanup.microdnf
+    - name: telicent.container.util.devtools

--- a/modules/nginx/130/configure.sh
+++ b/modules/nginx/130/configure.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env sh
+
+#!/bin/bash
+set -e
+
+NGINX_VERSION="${NGINX_VERSION:-1.30.1}"
+NGINX_SRC_URL="http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
+
+RED="\033[31m"
+END="\033[0m"
+
+log() {
+    echo "[INFO] $1"
+}
+
+error_exit() {
+    echo -e "${RED} [ERROR] $1 ${END}" >&2
+    exit 1
+}
+
+BUILD_DIR="/tmp/nginx-build"
+INSTALL_PREFIX="/usr/local/nginx"
+
+log "Preparing build environment..."
+mkdir -p $BUILD_DIR
+cd $BUILD_DIR
+
+log "Setting up log directory and permissions..."
+
+mkdir -p /var/log/nginx
+chown -R user:user /var/log/nginx
+chmod -R g+w /var/log/nginx
+ln -sf /dev/stdout /var/log/nginx/access.log
+ln -sf /dev/stderr /var/log/nginx/error.log
+
+log "Log directory and permissions configured successfully."
+
+log "Downloading NGINX source..."
+wget "${NGINX_SRC_URL}"
+wget "${NGINX_SRC_URL}.asc"
+
+log "Importing NGINX GPG key..."
+gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "${NGINX_GPG_KEY}"
+
+log "Verifying NGINX source tarball..."
+TARBALL="nginx-${NGINX_VERSION}.tar.gz"
+SIGNATURE="${TARBALL}.asc"
+gpg --verify "${SIGNATURE}" "${TARBALL}"
+
+log "Extracting NGINX source..."
+extract_with() {
+    local label="$1"
+    shift
+    log "Trying extractor: ${label}"
+    "$@" || return 1
+    return 0
+}
+
+extracted="false"
+if command -v bsdtar >/dev/null 2>&1; then
+    if extract_with "bsdtar" bsdtar -xpf "${TARBALL}"; then
+        extracted="true"
+    fi
+fi
+
+if [ "$extracted" != "true" ]; then
+    if extract_with "tar (safe flags)" tar -xzf "${TARBALL}" \
+        --no-same-owner --no-same-permissions --delay-directory-restore --no-xattrs --no-acls --no-selinux; then
+        extracted="true"
+    fi
+fi
+
+if [ "$extracted" != "true" ]; then
+    if extract_with "tar (basic)" tar -xzf "${TARBALL}"; then
+        extracted="true"
+    fi
+fi
+
+if [ "$extracted" != "true" ]; then
+    error_exit "Failed to extract NGINX tarball with all available extractors."
+fi
+cd "nginx-${NGINX_VERSION}"
+
+log "Configuring NGINX..."
+./configure \
+  --prefix=$INSTALL_PREFIX \
+  --user=nginx \
+  --group=nginx \
+  --with-http_ssl_module \
+  --with-http_v2_module \
+  --with-http_gzip_static_module \
+  --with-stream \
+  --with-pcre
+
+log "Building NGINX..."
+make -j$(nproc)
+
+log "Installing NGINX..."
+make install
+
+log "Implementing rootless changes for NGINX configuration..."
+sed -i 's,listen       80;,listen       8080;,' /usr/local/nginx/conf/nginx.conf
+sed -i '/user  nginx;/d' /usr/local/nginx/conf/nginx.conf
+sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /usr/local/nginx/conf/nginx.conf
+sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /usr/local/nginx/conf/nginx.conf
+
+log "Adjusting permissions for rootless operation..."
+#chown -R $UID:0 /usr/local/nginx/cache
+#chmod -R g+w /usr/local/nginx/cache
+#chown -R $UID:0 /usr/local/nginx/conf
+#chmod -R g+w /usr/local/nginx/conf
+chown -R $UID:0 $INSTALL_PREFIX
+chmod -R g+w $INSTALL_PREFIX
+
+
+log "Adding root to nginx group..."
+usermod -a -G $UID root
+
+log "Cleaning up build environment..."
+cd /
+rm -rf $BUILD_DIR
+
+ln -s $INSTALL_PREFIX/sbin/nginx /usr/sbin/nginx
+log "NGINX $NGINX_VERSION installation complete and ready for rootless operation!"

--- a/modules/nginx/130/module.yaml
+++ b/modules/nginx/130/module.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+
+name: "telicent.container.nginx130"
+version: "1.0.0"
+
+description: "Builds and installs NGINX 1.30.1 on UBI9 Minimal and configures it to run as a non-root user (GUID 185)."
+
+envs:
+  - name: "NGINX_VERSION"
+    value: "1.30.1"
+  - name: "NGINX_GPG_KEY"
+    value: "D6786CE303D9A9022998DC6CC8464D549AF75C0A"
+  - name: UID
+    value: "185"
+
+modules:
+  repositories:
+    - path: ../modules
+  install:
+    - name: telicent.container.util.pkg-update
+    - name: telicent.container.util.tzdata
+    - name: telicent.container.tar-gzip
+    - name: telicent.container.user
+
+packages:
+  install:
+    - glibc-langpack-en
+    - gcc
+    - gcc-c++
+    - make
+    - pcre2-devel
+    - zlib-devel
+    - openssl-devel
+    - wget
+    - gnupg2
+    - ca-certificates
+    - bsdtar
+
+execute:
+  - script: configure.sh


### PR DESCRIPTION
Fixes CVE-2026-42945 (Critical) and CVE-2026-27651/27654/32647 (High).
nginx 1.27.2 has no patch in the 1.27 line; minimum fix version is 1.30.1.

---
 
 
Ticket: https://telicent.atlassian.net/browse/TELDEVOPS-1097

### Goal

Add nginx 1.30.1 base image to resolve four CVEs with no fix available in the 1.27 line.

| CVE | Severity | Fixed in |
|-----|----------|----------|
| CVE-2026-42945 | Critical | 1.30.1 |
| CVE-2026-27651 | High | 1.28.3 / 1.29.7 |
| CVE-2026-27654 | High | 1.28.3 / 1.29.7 |
| CVE-2026-32647 | High | 1.28.3 / 1.29.7 |

### Work Completed

- `modules/nginx/130/module.yaml` — new CEKit module, nginx 1.30.1, same structure as 1.29
- `modules/nginx/130/configure.sh` — build-from-source script, identical to 1.29 except default version
- `image-descriptors/telicent-base-nginx130.yaml` — image descriptor producing `telicent-nginx1.30`


### Testing Method

1. CI Grype scan on the built image should show CVE-2026-42945 resolved
2. `.dev/build-nginx130.sh`:
```
==> Verifying nginx version in telicent-nginx1.30:1.0.0
    nginx version: nginx/1.30.1
==> OK
```
