### PR TITLE
fix(nodejs22): enable module stream before package install

### DIFF
--- a/modules/nodejs/22/exec.sh
+++ b/modules/nodejs/22/exec.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-microdnf -y module disable nodejs
-microdnf -y module enable nodejs:$NODEJS_VERSION

--- a/modules/nodejs/22/module.yaml
+++ b/modules/nodejs/22/module.yaml
@@ -12,6 +12,11 @@ labels:
 - name: "org.telicent.product.nodejs.version"
   value: *nodever
 
+# telicent.container.util.pkg-nodejs (used by nodejs20) hard-codes NODEJS_VERSION=20.
+# pkg-nodejs22 is a minimal fork that sets NODEJS_VERSION=22 and enables the
+# nodejs:22 module stream as a dependency — before packages: install runs.
+# PATH/NPM_CONFIG_PREFIX/HOME are wired here (previously provided by pkg-nodejs).
+
 envs:
   - name: "HOME"
     value: "/home/user"

--- a/modules/nodejs/22/module.yaml
+++ b/modules/nodejs/22/module.yaml
@@ -12,11 +12,6 @@ labels:
 - name: "org.telicent.product.nodejs.version"
   value: *nodever
 
-# NODEJS_VERSION is set at descriptor level (mirrors nodejs20 pattern).
-# telicent.container.util.pkg-nodejs is intentionally absent: that module
-# hard-codes NODEJS_VERSION=20 and would override the descriptor env.
-# exec.sh handles the microdnf module enable directly.
-# PATH/NPM_CONFIG_PREFIX/HOME are wired here (previously provided by pkg-nodejs).
 envs:
   - name: "HOME"
     value: "/home/user"
@@ -27,6 +22,7 @@ envs:
 
 modules:
   install:
+    - name: telicent.container.util.pkg-nodejs22
     - name: telicent.container.user
     - name: telicent.container.util.pkg-update
     - name: telicent.container.util.tzdata
@@ -39,5 +35,3 @@ packages:
     - findutils
     - which
 
-execute:
-  - script: exec.sh

--- a/modules/util/pkg-nodejs22/exec.sh
+++ b/modules/util/pkg-nodejs22/exec.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+microdnf -y module disable nodejs
+microdnf -y module enable nodejs:$NODEJS_VERSION

--- a/modules/util/pkg-nodejs22/module.yaml
+++ b/modules/util/pkg-nodejs22/module.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+name: telicent.container.util.pkg-nodejs22
+version: '1.0'
+description: "Enable NodeJS 22 module stream before package install"
+
+envs:
+  - name: "NODEJS_VERSION"
+    value: "22"
+
+execute:
+- script: exec.sh


### PR DESCRIPTION
Ticket: TELDEVOPS-1057

### Goal

Fix nodejs22 base image so it installs Node 22 instead of Node 16.

### Work Completed

cekit processes module dependencies before the parent module's `packages:` section. The nodejs22 module ran `exec.sh` (which enables the nodejs:22 stream) as a post-install `execute:` script — after `microdnf install nodejs` had already installed the default stream (Node 16).

New `pkg-nodejs22` sub-module enables the stream as a module dependency, before package install. Mirrors the working `pkg-nodejs` pattern used by nodejs20.

### Testing Method

1. `.dev/build-nodejs22.sh` — image builds, script verifies `node --version` >= 22
2. `docker run --rm telicent-nodejs22:latest node --version` → `v22.22.2`
3. End-to-end: built a Node/Hono BFF app (`be-for-fe-app`) on top of this image and ran the smoke test

Test script: `fe-mono-closed/packages/be-for-fe-app/scripts/test-docker-local.sh`

<details>
<summary><code>.dev/build-nodejs22.sh</code> output</summary>

```
==> Building telicent-nodejs22 from image-descriptors/telicent-base-nodejs22.yaml
Generating files for docker engine
Initializing image descriptor...
Copying resource 'modules'...
Finished!
Image ID 8059966c06bc built and available under following tags: telicent-nodejs22:1.0.3, telicent-nodejs22:latest
==> Verifying Node version in telicent-nodejs22:1.0.3
    node v22.22.2
==> OK
```

</details>

<details>
<summary><code>test-docker-local.sh</code> output (be-for-fe-app on this image)</summary>

```
== fe-spa-docker build
APP_NAME=be-for-fe
image_run: fe-mono-closed-run-local
#2 [internal] load metadata for docker.io/library/telicent-nodejs22:latest
#4 [1/4] FROM docker.io/library/telicent-nodejs22:latest (CACHED)
Skipping scan (--no-scan)

== fe-spa-docker run (starting container)
   waiting for server...

== GET /__meta
{
  "startedAt": "2026-05-29T17:10:28.311Z",
  "uptimeMs": 1027,
  "pid": 1,
  "ontology": {
    "done": false,
    "inFlight": false,
    "stylesLoaded": 0,
    "labelsLoaded": 0,
    "lastError": null
  }
}

== GET /entity-graph (expect 401)
   HTTP 401

== GET /glommer (expect 401)
   HTTP 401

== GET /debug (expect 401)
   HTTP 401

== PASS
```

</details>

### Engineering Notes

The original module.yaml comment said "pkg-nodejs is intentionally absent: that module hard-codes NODEJS_VERSION=20." Correct diagnosis, 
wrong! 
the replacement `exec.sh` ran too late in the cekit lifecycle. The new `pkg-nodejs22` module is a minimal fork of `pkg-nodejs` with `NODEJS_VERSION=22`.