### PR TITLE
fix(nginx): bump 1.30.1 to 1.30.2 for CVE-2026-9256

### DIFF
--- a/modules/nginx/130/configure.sh
+++ b/modules/nginx/130/configure.sh
@@ -3,7 +3,7 @@
 #!/bin/bash
 set -e
 
-NGINX_VERSION="${NGINX_VERSION:-1.30.1}"
+NGINX_VERSION="${NGINX_VERSION:-1.30.2}"
 NGINX_SRC_URL="http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 
 RED="\033[31m"

--- a/modules/nginx/130/module.yaml
+++ b/modules/nginx/130/module.yaml
@@ -3,11 +3,11 @@ schema_version: 1
 name: "telicent.container.nginx130"
 version: "1.0.0"
 
-description: "Builds and installs NGINX 1.30.1 on UBI9 Minimal and configures it to run as a non-root user (GUID 185)."
+description: "Builds and installs NGINX 1.30.2 on UBI9 Minimal and configures it to run as a non-root user (GUID 185)."
 
 envs:
   - name: "NGINX_VERSION"
-    value: "1.30.1"
+    value: "1.30.2"
   - name: "NGINX_GPG_KEY"
     value: "D6786CE303D9A9022998DC6CC8464D549AF75C0A"
   - name: UID


### PR DESCRIPTION
Fixes CVE-2026-9256 (Critical). Heap buffer overflow in `ngx_http_rewrite_module` via overlapping PCRE captures.

---

Ticket: CVE-2026-9256

### Goal

Bump nginx 1.30 base image from 1.30.1 to 1.30.2 to resolve CVE-2026-9256.

| CVE | Severity | Fixed in |
|-----|----------|----------|
| CVE-2026-9256 | Critical (CVSS 9.2) | 1.30.2 |

### Work Completed

- `modules/nginx/130/module.yaml` — `NGINX_VERSION` 1.30.1 → 1.30.2
- `modules/nginx/130/configure.sh` — default fallback 1.30.1 → 1.30.2

### Testing Method

1. CI Grype scan on the built image should show CVE-2026-9256 resolved
2. `.dev/build-nginx130.sh`:
```
==> Verifying nginx version in telicent-nginx1.30:1.0.4
    nginx version: nginx/1.30.2
==> OK
```