### PR TITLE
fix(nodejs22): strip npm CLI to cut CVE surface (picomatch HIGH)

### DIFF
--- a/image-descriptors/telicent-base-nodejs22.yaml
+++ b/image-descriptors/telicent-base-nodejs22.yaml
@@ -34,7 +34,7 @@ labels:
     value: "Telicent OSS"
 
 ports:
-- value: 8080
+  - value: 8080
 
 envs:
   - name: "LANG"
@@ -50,13 +50,14 @@ packages:
 
 modules:
   repositories:
-   - path: ../modules
+    - path: ../modules
   install:
     - name: telicent.container.nodejs
       version: "22"
     - name: telicent.container.util.cleanup.microdnf
     - name: telicent.container.util.devtools
+    - name: telicent.container.util.cleanup.npm
 
 # CHANGE_CHECKSUM_TO_FORCE_REBUILD
 # Base: v1.0.0
-# When: 2026-05-15T00:00:00.000Z
+# When: 2026-06-01T00:00:00.000Z

--- a/modules/util/cleanup/npm/cleanup
+++ b/modules/util/cleanup/npm/cleanup
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Why rm?
+# - npm ships as files inside the nodejs rpm
+# - reduce cve surface area
+# note: node binary is unaffected
+rm -rf /usr/lib/node_modules/npm

--- a/modules/util/cleanup/npm/module.yaml
+++ b/modules/util/cleanup/npm/module.yaml
@@ -1,10 +1,9 @@
 schema_version: 1
 
 name: "telicent.container.util.cleanup.npm"
-version: "1.0.0"
+version: "1.0.1"
 
-description: "Removes npm cli from OS"
+description: "Removes the npm CLI. It ships as files inside the nodejs rpm (no separate npm package), so it is deleted directly rather than via the package manager."
 
-packages:
-  remove:
-    - npm
+execute:
+  - script: cleanup


### PR DESCRIPTION
Ressurrected  🪦  some abandoned work from Georgi to remove npm

npm is not needed at container runtime (only `node`); only adds attack surface.

The cleanup.npm module did `microdnf remove npm`, which failed. npm ships as files inside the nodejs rpm, not a separate package.

Used `rm` instead.

Verified locally 
- cekit build docker: image 295MB->204MB (-31%)
- node v22.22.2 ,  no npm/npx,  picomatch removed (CVE motivation)
- my test node app builds + runs on the new base (curl endpoints wokrs)

Feels good man.

My flipping ide added whitespace. Sorry.