### PR TITLE
chore(vex): update gnutls CVE statements and add tar CVE suppression

### DIFF
--- a/.vex/CVE-2026-33845.openvex.json
+++ b/.vex/CVE-2026-33845.openvex.json
@@ -1,27 +1,18 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-be9bb9ec-1c5f-4fd2-92ca-68140b7fba14",
+  "@id": "https://openvex.dev/docs/public/vex-46a1842a-8ffd-4bf0-b216-3cf654d09c72",
   "author": "Telicent Ltd",
-  "timestamp": "2026-05-21T12:57:20Z",
+  "timestamp": "2026-06-10T12:16:51Z",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2026-33845"
       },
-      "timestamp": "2026-05-21T12:57:20Z",
+      "timestamp": "2026-06-10T12:16:51Z",
       "products": [
         {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-4.el9_8?arch=x86_64&distro=redhat-9.8"
-        },
-        {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-4.el9_8?arch=aarch64&distro=redhat-9.8"
-        },
-        {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-4.el9?arch=aarch64&distro=redhat-9.8"
-        },
-        {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-3.el9?arch=x86_64&distro=redhat-9.8"
+          "@id": "pkg:rpm/redhat/gnutls@3.8.3-10.el9_7?arch=x86_64&distro=redhat-9.7"
         }
       ],
       "status": "not_affected",

--- a/.vex/CVE-2026-33846.openvex.json
+++ b/.vex/CVE-2026-33846.openvex.json
@@ -1,21 +1,18 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-bfdde5f5-c355-4ddb-82a3-34b8346df957",
+  "@id": "https://openvex.dev/docs/public/vex-7e3e1cc2-ad25-4b53-9ce2-aa0336c2d501",
   "author": "Telicent Ltd",
-  "timestamp": "2026-05-21T12:57:20Z",
+  "timestamp": "2026-06-10T12:16:51Z",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2026-33846"
       },
-      "timestamp": "2026-05-21T12:57:20Z",
+      "timestamp": "2026-06-10T12:16:51Z",
       "products": [
         {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-4.el9_8?arch=x86_64&distro=redhat-9.8"
-        },
-        {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-3.el9?arch=x86_64&distro=redhat-9.8"
+          "@id": "pkg:rpm/redhat/gnutls@3.8.3-10.el9_7?arch=x86_64&distro=redhat-9.7"
         }
       ],
       "status": "not_affected",

--- a/.vex/CVE-2026-42009.openvex.json
+++ b/.vex/CVE-2026-42009.openvex.json
@@ -1,21 +1,18 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-c452586a-90b1-4066-a38c-fab79a4eca76",
+  "@id": "https://openvex.dev/docs/public/vex-591739b1-9429-44ef-99ac-840d5e88f447",
   "author": "Telicent Ltd",
-  "timestamp": "2026-05-21T12:57:20Z",
+  "timestamp": "2026-06-10T12:16:51Z",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2026-42009"
       },
-      "timestamp": "2026-05-21T12:57:20Z",
+      "timestamp": "2026-06-10T12:16:51Z",
       "products": [
         {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-4.el9_8?arch=x86_64&distro=redhat-9.8"
-        },
-        {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-3.el9?arch=x86_64&distro=redhat-9.8"
+          "@id": "pkg:rpm/redhat/gnutls@3.8.3-10.el9_7?arch=x86_64&distro=redhat-9.7"
         }
       ],
       "status": "not_affected",

--- a/.vex/CVE-2026-42010.openvex.json
+++ b/.vex/CVE-2026-42010.openvex.json
@@ -1,21 +1,18 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-292c9882-2678-413b-b0df-1642b041695c",
+  "@id": "https://openvex.dev/docs/public/vex-5c2d11e9-7871-4e4d-9676-3d719b570a46",
   "author": "Telicent Ltd",
-  "timestamp": "2026-05-21T12:57:20Z",
+  "timestamp": "2026-06-10T12:16:51Z",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2026-42010"
       },
-      "timestamp": "2026-05-21T12:57:20Z",
+      "timestamp": "2026-06-10T12:16:51Z",
       "products": [
         {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-4.el9_8?arch=x86_64&distro=redhat-9.8"
-        },
-        {
-          "@id": "pkg:rpm/redhat/gnutls@3.8.10-3.el9?arch=x86_64&distro=redhat-9.8"
+          "@id": "pkg:rpm/redhat/gnutls@3.8.3-10.el9_7?arch=x86_64&distro=redhat-9.7"
         }
       ],
       "status": "not_affected",

--- a/vex/CVE-2026-4878.json
+++ b/vex/CVE-2026-4878.json
@@ -1,0 +1,23 @@
+{
+    "@context": "https://openvex.dev/ns/v0.2.0",
+    "@id": "https://telicent.io/vex/telicent-auth-server-grype-suppression-20260414",
+    "author": "Telicent Ltd",
+    "timestamp": "2026-04-14T11:39:00",
+    "version": 1,
+    "statements": [
+        {
+            "vulnerability": {
+                "name": "CVE-2026-4878"
+            },
+            "timestamp": "2026-04-14T11:39:00",
+            "products": [
+                {
+                    "@id": "pkg:rpm/redhat/tar@2:1.34-7.el9?distro=redhat-9.6"
+                }
+            ],
+            "status": "not_affected",
+            "justification": "vulnerable_code_not_in_execute_path",
+            "impact_statement": "The vulnerability affects the 'tar' utility, allowing root to extract archives with preserved setuid/setgid bits. This is marked as 'wont-fix' by the distro. In this environment, the application does not execute 'tar' as root with untrusted, user-provided archives, meaning the vulnerable code path is not exercised."
+        }
+    ]
+}


### PR DESCRIPTION
Refresh VEX statements for CVE-2026-33845/33846/42009/42010 to target the gnutls 3.8.3-10.el9_7 package on RHEL 9.7, and add a new suppression for CVE-2026-4878 (tar) with vulnerable_code_not_in_execute_path justification.