### PR TITLE
fix: Updating for CVE-2026-49268 (brought in by Apache Jena Fuseki)

### DIFF
--- a/.vex/CVE-2026-49268.openvex.json
+++ b/.vex/CVE-2026-49268.openvex.json
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b9dcdef7-3217-4e69-83a9-22e23332d4e1",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-06-19T13:44:55Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-49268"
+      },
+      "timestamp": "2026-06-19T13:44:55Z",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.shiro/shiro-core@2.1.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Our applications do not utilize the Default LDAP Realm logic and so is never exposed."
+    }
+  ]
+}


### PR DESCRIPTION
As spotted here: https://github.com/telicent-oss/rdf-abac/actions/runs/27828816573

It's on some LDAP logic that we don't use getting pulled in by Apache Jena (Fuseki). 