### PR TITLE
chore: Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: 
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Enables Dependabot as a number of the workflows are complaining about outdated Node 20 based actions so we need to get those updated before the Node 20 support is removed from GitHub Actions