### PR TITLE
fix(cve): Add VEX suppressions for new CVEs

### DIFF
--- a/.vex/CVE-2026-54369.openvex.json
+++ b/.vex/CVE-2026-54369.openvex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-d8adb87a4a745d5452f56b33db1c2caa053f22e1515f87406f68d18e46c7ce8d",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-06-30T10:29:33.10247+01:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54369"
+      },
+      "timestamp": "2026-06-30T10:29:33.102471+01:00",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64\u0026distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=aarch64\u0026distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "This vulnerability affects the low level libacl system library which no Telicent product code ever calls directly.  Exploiting the vulnerability involves creating malicious symlinks which requires direct access to the container filesystem and shell which attackers do not have in our deployments."
+    }
+  ]
+}

--- a/.vex/CVE-2026-54371.openvex.json
+++ b/.vex/CVE-2026-54371.openvex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-7346fbe97d9f106ce1e522cb4bb3fceec0a47d9282d85033858c54c3a5302c3b",
+  "author": "Unknown Author",
+  "timestamp": "2026-06-30T10:36:10.317597+01:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54371"
+      },
+      "timestamp": "2026-06-30T10:36:10.317599+01:00",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64\u0026distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=aarch64\u0026distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "This vulnerability affects the low level libattr system library which no Telicent product code ever calls directly.  Exploiting the vulnerability involves creating malicious symlinks which requires direct access to the container filesystem and shell which attackers do not have in our deployments."
+    }
+  ]
+}


### PR DESCRIPTION
Adds VEX suppressions for CVE-2026-54369 and CVE-2026-54371 which are both symlink traversal bugs in low level OS libraries.  Exploiting these would require the attacker to both be able to write symlinks to the container filesystem and to execute code in the container since no Telicent code uses these low level libraries directly.