### PR TITLE
VEX statement for CVE-2026-58016

### DIFF
--- a/.vex/CVE-2026-58016.openvex.json
+++ b/.vex/CVE-2026-58016.openvex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-6558ec15-8280-4c84-8568-a9f4002f0579",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-02T09:03:01Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-58016"
+      },
+      "timestamp": "2026-07-02T09:03:01Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/glib2@2.68.4-19.el9_8.1?arch=x86_64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/glib2@2.68.4-19.el9_8.1?arch=aarch64&distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "This vulnerability relates to D-Bus implementation in glibc.  D-Bus is a low level intra-process communication mechanism.  Telicent containers contain a single process and perform no intra-process communications so are not vulnerable."
+    }
+  ]
+}


### PR DESCRIPTION
This pertains to a D-Bus vulnerability in glibc.  D-Bus is a low level intra-process communication mechanism.  As Telicent containers all run a single process with no intra-process communication within the container they are not vulnerable to this CVE