### PR TITLE
fix(nginx130): bump nginx to 1.30.3 for CVE-2026-42055

### DIFF
--- a/.vex/CVE-2026-42055.openvex.json
+++ b/.vex/CVE-2026-42055.openvex.json
@@ -16,7 +16,15 @@
         }
       ],
       "status": "fixed",
-      "impact_statement": "nginx 1.30.3 is the upstream stable-branch fix for CVE-2026-42055 (released 2026-06-17). Grype matches it via the NVD CPE range >= 1.13.10, < 1.31.2, which spans both nginx branches and does not distinguish the 1.30.3 stable fix from the 1.31.2 mainline fix, so it flags the patched 1.30.3 build as a false positive. The nginx binary in this image contains the fix."
+      "impact_statement": "nginx 1.30.3 is the upstream stable-branch fix for CVE-2026-42055 (released 2026-06-17). Grype matches it via the NVD CPE range >= 1.13.10, < 1.31.2, which spans both nginx branches and does not distinguish the 1.30.3 stable fix from the 1.31.2 mainline fix, so it flags the patched 1.30.3 build as a false positive. The nginx binary in this image contains the fix.",
+      "_rationale": {
+        "_rationale_note": "Non-standard field. OpenVEX consumers ignore unknown keys; this records the proof so the suppression needs no re-investigation. Verified 2026-07-03.",
+        "_rationale_fix_present": "nginx.org security_advisories lists CVE-2026-42055 fixed in stable 1.30.3 and mainline 1.31.2. This image builds nginx 1.30.3 from source (modules/nginx/130), so the fix is present.",
+        "_rationale_raw_nvd_is_correct": "Raw NVD CPE data for the stable branch is branch-accurate: cpe:2.3:a:f5:nginx_open_source uses versionStartIncluding 1.30.0, versionEndExcluding 1.30.3 (excludes 1.30.3), plus an exact match on 1.31.1. NVD alone would NOT flag 1.30.3.",
+        "_rationale_grype_db_is_the_gate": "CI runs grype, which uses its own normalized DB, not raw NVD. grype db search for CVE-2026-42055 returns constraint '>= 1.13.10, < 1.31.2 || >= 1.30.2, < 1.30.3' in the nvd:cpe namespace. The first clause '< 1.31.2' includes 1.30.3, so grype flags the patched build. This is the false positive, and it originates in grype's normalization, not in NVD.",
+        "_rationale_scan_proof": "grype 0.111.1 (DB updated 2026-07-03) scanning an SBOM of nginx 1.30.3 (cpe:2.3:a:f5:nginx_open_source:1.30.3): WITHOUT this VEX reports 'CVE-2026-42055 High'; WITH '--vex <this file>' reports the same finding as '(suppressed by VEX)'. The nginx source build carries no rpm/apk distro namespace, so CPE matching applies and the '< 1.31.2' clause fires.",
+        "_rationale_becomes_noop_when": "If grype later refines this constraint to match NVD's branch-split (< 1.30.3), grype stops flagging 1.30.3 and this VEX becomes a harmless no-op. review-stale-openvex.yaml is expected to catch that."
+      }
     }
   ]
 }

--- a/.vex/CVE-2026-42055.openvex.json
+++ b/.vex/CVE-2026-42055.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-36678f9f-2b9d-4710-88d8-426eb3a6c5c4",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-02T22:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42055"
+      },
+      "timestamp": "2026-07-02T22:00:00Z",
+      "products": [
+        {
+          "@id": "pkg:generic/nginx@1.30.3"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "nginx 1.30.3 is the upstream stable-branch fix for CVE-2026-42055 (released 2026-06-17). Grype matches it via the NVD CPE range >= 1.13.10, < 1.31.2, which spans both nginx branches and does not distinguish the 1.30.3 stable fix from the 1.31.2 mainline fix, so it flags the patched 1.30.3 build as a false positive. The nginx binary in this image contains the fix."
+    }
+  ]
+}

--- a/image-descriptors/telicent-base-nginx130.yaml
+++ b/image-descriptors/telicent-base-nginx130.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 from: "redhat/ubi9-minimal:9.8-1782797275"
 
 name: &name "telicent-nginx1.30"
-version: &version "1.0.9"
+version: &version "1.0.10"
 description: "Telicent's NGINX base image built on Red Hat UBI9 minimal."
 
 # Ensure compliance with Red Hat UBI EULA

--- a/modules/nginx/130/configure.sh
+++ b/modules/nginx/130/configure.sh
@@ -3,7 +3,7 @@
 #!/bin/bash
 set -e
 
-NGINX_VERSION="${NGINX_VERSION:-1.30.2}"
+NGINX_VERSION="${NGINX_VERSION:-1.30.3}"
 NGINX_SRC_URL="http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 
 RED="\033[31m"

--- a/modules/nginx/130/module.yaml
+++ b/modules/nginx/130/module.yaml
@@ -3,13 +3,13 @@ schema_version: 1
 name: "telicent.container.nginx130"
 version: "1.0.0"
 
-description: "Builds and installs NGINX 1.30.2 on UBI9 Minimal and configures it to run as a non-root user (GUID 185)."
+description: "Builds and installs NGINX 1.30.3 on UBI9 Minimal and configures it to run as a non-root user (GUID 185)."
 
 envs:
   - name: "NGINX_VERSION"
-    value: "1.30.2"
+    value: "1.30.3"
   - name: "NGINX_GPG_KEY"
-    value: "D6786CE303D9A9022998DC6CC8464D549AF75C0A"
+    value: "43387825DDB1BB97EC36BA5D007C8D7C15D87369"
   - name: UID
     value: "185"
 


### PR DESCRIPTION
📣 **AI-generated: Requires line-by-line review**

### Goal

Fixes CVE-2026-42055

### Work Completed

- Bump nginx 1.30.2 to 1.30.3 (upstream stable-branch fix, released 2026-06-17)
- Switch `NGINX_GPG_KEY` to ngnix maintainer Roman Arutyunyan's key, which signs the 1.30.3 tarball (the prior key does not)
- Add `.vex/CVE-2026-42055.openvex.json` (`status: fixed`) to clear a grype false positive
  - cause: grype normalizes the CPE range to `< 1.31.2`, which matches the patched 1.30.3

### Testing Method

Built the image locally (nginx/1.30.3). grype 0.111.1 flags CVE-2026-42055 as HIGH on the SBOM, and suppresses it with `--vex`.

### Code Review Tips

Added custom `_rationale` key
