### PR TITLE
fix: VEX no-fix curl CVEs + rebuild nodejs22 for 22.23.1

### DIFF
--- a/.vex/CVE-2026-11352.openvex.json
+++ b/.vex/CVE-2026-11352.openvex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-3630c2c7-0a2d-4b9a-8318-faccf7fb602b",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-08T16:09:38Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-11352"
+      },
+      "timestamp": "2026-07-08T16:09:38Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "curl-minimal and libcurl-minimal are present only in the UBI9 base layer; no fix is yet available from Red Hat. The image application runtimes do not invoke curl or link libcurl (the NodeJS runtime uses its built-in HTTP stack; the nginx image serves static content), so the vulnerable code is not reachable in normal operation. Re-evaluate when Red Hat ships a fixed el9 build. for CVE-2026-11352."
+    }
+  ]
+}

--- a/.vex/CVE-2026-11586.openvex.json
+++ b/.vex/CVE-2026-11586.openvex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-21e0f4ec-6353-42f6-a459-66a86d3da9f2",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-08T16:09:38Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-11586"
+      },
+      "timestamp": "2026-07-08T16:09:38Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "curl-minimal and libcurl-minimal are present only in the UBI9 base layer; no fix is yet available from Red Hat. The image application runtimes do not invoke curl or link libcurl (the NodeJS runtime uses its built-in HTTP stack; the nginx image serves static content), so the vulnerable code is not reachable in normal operation. Re-evaluate when Red Hat ships a fixed el9 build. for CVE-2026-11586."
+    }
+  ]
+}

--- a/.vex/CVE-2026-12064.openvex.json
+++ b/.vex/CVE-2026-12064.openvex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-444e1029-5f83-4b88-ab6c-15216b2b7432",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-08T16:09:38Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-12064"
+      },
+      "timestamp": "2026-07-08T16:09:38Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "curl-minimal and libcurl-minimal are present only in the UBI9 base layer; no fix is yet available from Red Hat. The image application runtimes do not invoke curl or link libcurl (the NodeJS runtime uses its built-in HTTP stack; the nginx image serves static content), so the vulnerable code is not reachable in normal operation. Re-evaluate when Red Hat ships a fixed el9 build. for CVE-2026-12064."
+    }
+  ]
+}

--- a/.vex/CVE-2026-8286.openvex.json
+++ b/.vex/CVE-2026-8286.openvex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-9426d365-38a9-471b-807a-76cf239067d0",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-08T16:09:38Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8286"
+      },
+      "timestamp": "2026-07-08T16:09:38Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "curl-minimal and libcurl-minimal are present only in the UBI9 base layer; no fix is yet available from Red Hat. The image application runtimes do not invoke curl or link libcurl (the NodeJS runtime uses its built-in HTTP stack; the nginx image serves static content), so the vulnerable code is not reachable in normal operation. Re-evaluate when Red Hat ships a fixed el9 build. for CVE-2026-8286."
+    }
+  ]
+}

--- a/.vex/CVE-2026-8925.openvex.json
+++ b/.vex/CVE-2026-8925.openvex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-eb8f9ec2-bb49-4b9b-b4b8-91c7ee43fb82",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-08T16:09:38Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8925"
+      },
+      "timestamp": "2026-07-08T16:09:38Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "curl-minimal and libcurl-minimal are present only in the UBI9 base layer; no fix is yet available from Red Hat. The image application runtimes do not invoke curl or link libcurl (the NodeJS runtime uses its built-in HTTP stack; the nginx image serves static content), so the vulnerable code is not reachable in normal operation. Re-evaluate when Red Hat ships a fixed el9 build. for CVE-2026-8925."
+    }
+  ]
+}

--- a/.vex/CVE-2026-9547.openvex.json
+++ b/.vex/CVE-2026-9547.openvex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-3ba363fb-2446-40dc-bd6d-447047c912f9",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-08T16:09:38Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-9547"
+      },
+      "timestamp": "2026-07-08T16:09:38Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/curl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=aarch64&distro=redhat-9.8"
+        },
+        {
+          "@id": "pkg:rpm/redhat/libcurl-minimal@7.76.1-40.el9?arch=x86_64&distro=redhat-9.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "curl-minimal and libcurl-minimal are present only in the UBI9 base layer; no fix is yet available from Red Hat. The image application runtimes do not invoke curl or link libcurl (the NodeJS runtime uses its built-in HTTP stack; the nginx image serves static content), so the vulnerable code is not reachable in normal operation. Re-evaluate when Red Hat ships a fixed el9 build. for CVE-2026-9547."
+    }
+  ]
+}

--- a/image-descriptors/telicent-base-nodejs22.yaml
+++ b/image-descriptors/telicent-base-nodejs22.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 from: "redhat/ubi9-minimal:9.8-1782797275"
 
 name: &name "telicent-nodejs22"
-version: &version "1.0.9"
+version: &version "1.0.10"
 description: "Telicent's NodeJS 22 base image built on Red Hat UBI9 minimal."
 
 # Ensure compliance with Red Hat UBI EULA
@@ -60,4 +60,7 @@ modules:
 
 # CHANGE_CHECKSUM_TO_FORCE_REBUILD
 # Base: v1.0.0
-# When: 2026-06-01T00:00:00.000Z
+# When: 2026-07-08T00:00:00.000Z
+# Rebuild to pull nodejs 22.23.1 (el9.8 appstream) — clears HIGH CVE-2026-12151,
+# CVE-2026-42338, CVE-2026-48618, CVE-2026-48933. CVE-2026-13149 has no upstream
+# fix yet and is NOT resolved by this rebuild.


### PR DESCRIPTION
📣 **AI-generated: Requires line-by-line review**

Clears the HIGH/CRITICAL findings that block downstream app publishes (fe-mono-closed showcase-app + be-for-fe-app) on the UBI9 base images.

### 1. curl — 6 no-fix HIGH CVEs → `not_affected` VEX
`curl-minimal` / `libcurl-minimal 7.76.1-40.el9`: CVE-2026-11352, -11586, -12064, -8286, -8925, -9547. No upstream (el9) fix available.

Added OpenVEX `not_affected` + `vulnerable_code_not_in_execute_path`, matching the repo's existing convention (e.g. python3.12 CVE-2024-12718). These packages ship in the UBI9 base layer but the image runtimes don't invoke curl or link libcurl (NodeJS uses its built-in HTTP stack; the nginx image serves static content). Generated with `generate_vex_statements.sh`; both arches, both packages.

**Verified:** `trivy-with-vex.sh image telicent/telicent-nodejs22:latest` moves all 6 (×2 packages) into *Suppressed Vulnerabilities*.

### 2. nodejs — bump `telicent-nodejs22` to pull 22.23.1
Current image ships `nodejs 22.22.2-1.module+el9.7.0` (5 HIGH CVEs). Bumped the descriptor version `1.0.9 → 1.0.10` and the force-rebuild timestamp so microdnf pulls **nodejs 22.23.1** from the live el9.8 appstream on rebuild.

Clears the 4 fixable CVEs: **CVE-2026-12151, -42338, -48618, -48933**.

### ⚠️ Not resolved by this PR: CVE-2026-13149 (nodejs, HIGH)
No upstream fix, and `nodejs` **is** in the execute path of a NodeJS runtime — so a `not_affected` VEX would be inaccurate. This needs an upstream Node fix or an explicit risk-acceptance decision; it is deliberately **not** suppressed here. Downstream `be-for-fe-app` will remain blocked on this one CVE until it's addressed.

### Verification note
Curl suppression verified locally. The nodejs rebuild result is verified by this repo's own build + scan CI on the PR.
