### PR TITLE
chore(security): VEX CVE-2026-13149 (brace-expansion ReDoS) not_affected for telicent-nodejs22

### DIFF
--- a/.vex/CVE-2026-13149.openvex.json
+++ b/.vex/CVE-2026-13149.openvex.json
@@ -26,7 +26,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
-      "impact_statement": "CVE-2026-13149 is an algorithmic-complexity denial of service in the brace-expansion npm package (exponential CPU when crafted input reaches expand()). brace-expansion is present only as a transitive dependency of the npm CLI. The telicent-nodejs22 build removes npm from the final image (cleanup.npm module; verified: npm, npx, and any brace-expansion files are absent), so the vulnerable code is not present in the published image. Scanners still match the CVE against the nodejs / nodejs-libs RPM version recorded in the RPM database. Products list the nodejs / nodejs-libs RPMs as scanned on 2026-07-20: x86_64 22.23.1-1.module+el9.8.0, aarch64 22.22.2-1.module+el9.7.0."
+      "impact_statement": "npm is removed from the telicent-nodejs22 image (cleanup.npm module), and brace-expansion ships only inside npm, so the vulnerable code is not present in the published image (verified on :latest: npm, npx, and brace-expansion files are all absent). CVE-2026-13149 is therefore a false positive from RPM metadata: Grype/Trivy match it against the nodejs / nodejs-libs RPM version recorded in the package database, not against files that exist in the image. Nothing in the image can reach the flaw and there is nothing to patch or remove. The flaw itself is an algorithmic-complexity denial of service in brace-expansion (exponential CPU when crafted input reaches expand()). Products list the nodejs / nodejs-libs RPMs as scanned on 2026-07-20: x86_64 22.23.1-1.module+el9.8.0, aarch64 22.22.2-1.module+el9.7.0."
     }
   ]
 }

--- a/.vex/CVE-2026-13149.openvex.json
+++ b/.vex/CVE-2026-13149.openvex.json
@@ -25,8 +25,8 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-13149 is a ReDoS / algorithmic-complexity flaw in the brace-expansion npm package, which ships transitively inside the npm CLI bundled with the nodejs RPM. Telicent Node images run the application via 'node server.js'; npm (and therefore brace-expansion) is not invoked at container runtime, so the vulnerable expand() code path is not exercised by the running service. No fixed RPM is available upstream (fix state: not-fixed). Products cover both published arches of telicent-nodejs22:latest at 2026-07-20: x86_64 nodejs 22.23.1-1.module+el9.8.0 and aarch64 nodejs 22.22.2-1.module+el9.7.0."
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "CVE-2026-13149 is an algorithmic-complexity denial of service in the brace-expansion npm package (exponential CPU when crafted input reaches expand()). brace-expansion is present only as a transitive dependency of the npm CLI. The telicent-nodejs22 build removes npm from the final image (cleanup.npm module; verified: npm, npx, and any brace-expansion files are absent), so the vulnerable code is not present in the published image. Scanners still match the CVE against the nodejs / nodejs-libs RPM version recorded in the RPM database. Products list the nodejs / nodejs-libs RPMs as scanned on 2026-07-20: x86_64 22.23.1-1.module+el9.8.0, aarch64 22.22.2-1.module+el9.7.0."
     }
   ]
 }

--- a/.vex/CVE-2026-13149.openvex.json
+++ b/.vex/CVE-2026-13149.openvex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1ae90252-f0f1-446d-8b73-fc6be24a1143",
+  "author": "Telicent Ltd",
+  "timestamp": "2026-07-20T13:32:04Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-13149"
+      },
+      "timestamp": "2026-07-20T13:32:04Z",
+      "products": [
+        {
+          "@id": "pkg:rpm/redhat/nodejs@22.23.1-1.module%2Bel9.8.0%2B24457%2B996af7aa?arch=x86_64&distro=redhat-9.8&epoch=1&modularitylabel=nodejs%3A22%3A9080020260626075442%3Arhel9"
+        },
+        {
+          "@id": "pkg:rpm/redhat/nodejs-libs@22.23.1-1.module%2Bel9.8.0%2B24457%2B996af7aa?arch=x86_64&distro=redhat-9.8&epoch=1&modularitylabel=nodejs%3A22%3A9080020260626075442%3Arhel9"
+        },
+        {
+          "@id": "pkg:rpm/redhat/nodejs@22.22.2-1.module%2Bel9.7.0%2B24157%2B8ddb2461?arch=aarch64&distro=redhat-9.8&epoch=1&modularitylabel=nodejs%3A22%3A9070020260401095228%3Arhel9"
+        },
+        {
+          "@id": "pkg:rpm/redhat/nodejs-libs@22.22.2-1.module%2Bel9.7.0%2B24157%2B8ddb2461?arch=aarch64&distro=redhat-9.8&epoch=1&modularitylabel=nodejs%3A22%3A9070020260401095228%3Arhel9"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-13149 is a ReDoS / algorithmic-complexity flaw in the brace-expansion npm package, which ships transitively inside the npm CLI bundled with the nodejs RPM. Telicent Node images run the application via 'node server.js'; npm (and therefore brace-expansion) is not invoked at container runtime, so the vulnerable expand() code path is not exercised by the running service. No fixed RPM is available upstream (fix state: not-fixed). Products cover both published arches of telicent-nodejs22:latest at 2026-07-20: x86_64 nodejs 22.23.1-1.module+el9.8.0 and aarch64 nodejs 22.22.2-1.module+el9.7.0."
+    }
+  ]
+}


### PR DESCRIPTION
📣 **AI-generated: Requires line-by-line review**

### Goal

npm is removed from telicent-nodejs22, so CVE-2026-13149 is a false positive: its flaw lives in brace-expansion, which ships only inside npm, and neither is in the image. This VEX marks it `not_affected` so the Grype/Trivy HIGH gate stops blocking publishes.

### Work Completed

- Add `.vex/CVE-2026-13149.openvex.json`: status `not_affected`, justification `vulnerable_code_not_present`
- Scope: `nodejs`, `nodejs-libs` on `:latest`, both arches
- Scanned: 2026-07-20 (x86_64 `22.23.1-el9.8.0`, aarch64 `22.22.2-el9.7.0`)

### Design Testing

No UI change.

### Testing Method

`trivy image --vex` on `:latest` leaves 0 unsuppressed CVE-2026-13149 matches on both arches (x86_64 by digest, aarch64 local).

### Engineering Notes

- Not present: `cleanup.npm` removes npm, so `npm`, `npx`, and brace-expansion files are all absent from `:latest`
- False positive: Grype/Trivy match the CVE against the nodejs/nodejs-libs RPM version in the package database, not against files in the image, so there is nothing to patch or remove
- Vuln: algorithmic-complexity DoS in brace-expansion, reached through `expand()`
- Consumers need no change: the shared Grype/Trivy scan actions already list this repo as a remote-vex source
